### PR TITLE
chore: add the k8s group back

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      kubernetes:
+        patterns:
+          - "k8s.io/apimachinery"
+          - "k8s.io/client-go"
+          - "k8s.io/apiserver"
+          - "k8s.io/code-generator"
+          - "k8s.io/component-base"
+          - "sigs.k8s.io/controller-runtime"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:
- add the k8s group back
 
**Which issue(s) this PR fixes**
Issue https://github.com/neuvector/neuvector-kubewarden-policy-converter/issues/12

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
