### PR TITLE
fix: update the function usage of convert and matrix

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -151,11 +151,16 @@ func (r *RuleConverter) processSingleRule(rule *nvapis.RESTAdmissionRule) rulePa
 
 func (r *RuleConverter) renderResultsTable(results []ruleParsingResult) {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetColWidth(defaultColumnWidth)
-	table.SetHeader([]string{"ID", "STATUS", "NOTES"})
+	table.Header([]string{"ID", "STATUS", "NOTES"})
 	for _, result := range results {
-		table.Append([]string{strconv.FormatUint(uint64(result.id), 10), result.status, result.notes})
+		data := []string{
+			strconv.FormatUint(uint64(result.id), 10),
+			result.status,
+			result.notes,
+		}
+		table.Append(data)
 	}
+
 	table.Render()
 }
 

--- a/internal/convert/matrix.go
+++ b/internal/convert/matrix.go
@@ -409,8 +409,7 @@ func (cm *CriteriaMatrix) isSupportedRule(rule *nvapis.RESTAdmissionRule) (bool,
 
 func (cm *CriteriaMatrix) dumpSupportedCriteriaTable() {
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetColWidth(defaultColumnWidth)
-	table.SetHeader([]string{"Criterion Name", "Supported", "Note"})
+	table.Header([]string{"Criterion Name", "Supported", "Note"})
 
 	var mappings []criterionMapping
 	for _, mapping := range cm.data {


### PR DESCRIPTION
**What this PR does / why we need it**:
- update the function usage of convert.go and matrix.go, due to https://github.com/neuvector/neuvector-kubewarden-policy-converter/pull/21

