### PR TITLE
test: prepare for envVars and envSecret

### DIFF
--- a/internal/convert/convert.go
+++ b/internal/convert/convert.go
@@ -71,6 +71,8 @@ func (r *RuleConverter) initHandlers() {
 		handlers.RuleRunAsRoot:                 handlers.NewContainerRunningAsUserHandler(),
 		handlers.RuleRunAsPrivileged:           handlers.NewPodPrivilegedHandler(),
 		handlers.RuleStorageClass:              handlers.NewPVCStorageClassHandler(),
+		handlers.RuleEnvVars:                   handlers.NewEnvVarHandler(),
+		handlers.RuleEnvVarSecret:              handlers.NewEnvVarSecretHandler(),
 	}
 }
 

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -314,6 +314,22 @@ func TestConvertSingleCriterion_PVCStorageClass(t *testing.T) {
 	}
 }
 
+func TestConvertSingleCriterion_EnvVar(t *testing.T) {
+	for _, ruleDir := range []string{
+		"../../test/rules/single_criterion/env_var/contains_all",
+		"../../test/rules/single_criterion/env_var/contains_any",
+		"../../test/rules/single_criterion/env_var/contains_other_than",
+		"../../test/rules/single_criterion/env_var/not_contains_any",
+	} {
+		testRuleConversion(t, ruleDir)
+	}
+}
+
+func TestConvertSingleCriterion_EnvVarSecret(t *testing.T) {
+	ruleDir := "../../test/rules/single_criterion/env_var_secret/secret_forbid"
+	testRuleConversion(t, ruleDir)
+}
+
 /*
 Multi-criteria conversion tests for compound rules and edge cases.
 */

--- a/internal/handlers/env_var_handler.go
+++ b/internal/handlers/env_var_handler.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/neuvector/neuvector-kubewarden-policy-converter/internal/share"
+	nvapis "github.com/neuvector/neuvector/controller/api"
+	nvdata "github.com/neuvector/neuvector/share"
+)
+
+type EnvVarHandler struct {
+	BasePolicyHandler
+
+	criteriaNegationMap map[string]string
+}
+
+const (
+	PolicyEnvironmentVariableURI = "registry://ghcr.io/kubewarden/policies/environment-variable-policy:v3.0.1"
+
+	RuleEnvVars = "envVars"
+)
+
+func NewEnvVarHandler() *EnvVarHandler {
+	return &EnvVarHandler{
+		BasePolicyHandler: BasePolicyHandler{
+			Unsupported: false,
+			SupportedOps: map[string]bool{
+				nvdata.CriteriaOpContainsAll:       true,
+				nvdata.CriteriaOpContainsAny:       true,
+				nvdata.CriteriaOpContainsOtherThan: true,
+				nvdata.CriteriaOpNotContainsAny:    true,
+			},
+			Name:               share.ExtractModuleName(PolicyEnvironmentVariableURI),
+			Module:             PolicyEnvironmentVariableURI,
+			ApplicableResource: ResourceWorkload,
+		},
+		criteriaNegationMap: map[string]string{
+			nvdata.CriteriaOpContainsAll:       "doesNotContainAllOf",
+			nvdata.CriteriaOpContainsAny:       "doesNotContainAnyOf",
+			nvdata.CriteriaOpContainsOtherThan: "containsOtherThan",
+			nvdata.CriteriaOpNotContainsAny:    "containsAnyOf",
+		},
+	}
+}
+
+func (h *EnvVarHandler) BuildPolicySettings(criteria []*nvapis.RESTAdmRuleCriterion) ([]byte, error) {
+	if len(criteria) != 1 {
+		return nil, errors.New("only one criterion is allowed")
+	}
+
+	settings := map[string]any{}
+	criterion := criteria[0]
+	negationCriteria, ok := h.criteriaNegationMap[criterion.Op]
+	if !ok {
+		return nil, fmt.Errorf("unsupported criteria operator: %s", criterion.Op)
+	}
+	settings["criteria"] = negationCriteria
+	settings["values"] = strings.Split(criterion.Value, ",")
+
+	settingsBytes, err := json.Marshal(settings)
+	if err != nil {
+		return nil, err
+	}
+	return settingsBytes, nil
+}

--- a/internal/handlers/env_var_handler_test.go
+++ b/internal/handlers/env_var_handler_test.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"testing"
+
+	nvapis "github.com/neuvector/neuvector/controller/api"
+	nvdata "github.com/neuvector/neuvector/share"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvVarPolicySettingsConversion(t *testing.T) {
+	handler := NewEnvVarHandler()
+
+	tests := []struct {
+		testCaseName     string
+		inputCriteria    []*nvapis.RESTAdmRuleCriterion
+		expectedSettings []byte
+		expectedError    error
+	}{
+		{
+			testCaseName: "env var contains all specified values",
+			inputCriteria: []*nvapis.RESTAdmRuleCriterion{
+				{
+					Name:  RuleEnvVars,
+					Op:    nvdata.CriteriaOpContainsAll,
+					Value: "foo,bar",
+				},
+			},
+			expectedSettings: []byte(
+				`{"criteria":"doesNotContainAllOf","values":["foo","bar"]}`,
+			),
+		},
+		{
+			testCaseName: "env var contains any specified value",
+			inputCriteria: []*nvapis.RESTAdmRuleCriterion{
+				{
+					Name:  RuleEnvVars,
+					Op:    nvdata.CriteriaOpContainsAny,
+					Value: "foo,bar",
+				},
+			},
+			expectedSettings: []byte(
+				`{"criteria":"doesNotContainAnyOf","values":["foo","bar"]}`,
+			),
+		},
+		{
+			testCaseName: "env var contains values other than specified",
+			inputCriteria: []*nvapis.RESTAdmRuleCriterion{
+				{
+					Name:  RuleEnvVars,
+					Op:    nvdata.CriteriaOpContainsOtherThan,
+					Value: "foo,bar",
+				},
+			},
+			expectedSettings: []byte(
+				`{"criteria":"containsOtherThan","values":["foo","bar"]}`,
+			),
+		},
+		{
+			testCaseName: "env var does not contain any specified value",
+			inputCriteria: []*nvapis.RESTAdmRuleCriterion{
+				{
+					Name:  RuleEnvVars,
+					Op:    nvdata.CriteriaOpNotContainsAny,
+					Value: "foo,bar",
+				},
+			},
+			expectedSettings: []byte(
+				`{"criteria":"containsAnyOf","values":["foo","bar"]}`,
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testCaseName, func(t *testing.T) {
+			generatedSettings, err := handler.BuildPolicySettings(tt.inputCriteria)
+			require.JSONEq(t, string(tt.expectedSettings), string(generatedSettings))
+			require.Equal(t, tt.expectedError, err)
+		})
+	}
+}

--- a/internal/handlers/env_var_secret_handler.go
+++ b/internal/handlers/env_var_secret_handler.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/neuvector/neuvector-kubewarden-policy-converter/internal/share"
+	nvapis "github.com/neuvector/neuvector/controller/api"
+	nvdata "github.com/neuvector/neuvector/share"
+)
+
+type EnvVarSecretHandler struct {
+	BasePolicyHandler
+}
+
+const (
+	RuleEnvVarSecret = "envVarSecrets" // #nosec G101 - This is a rule identifier, not a secret
+
+	PolicyEnvSecretScannerURI = "registry://ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v1.0.5" // #nosec G101 - This is a policy identifier, not a secret
+)
+
+func NewEnvVarSecretHandler() *EnvVarSecretHandler {
+	return &EnvVarSecretHandler{
+		BasePolicyHandler: BasePolicyHandler{
+			Unsupported: false,
+			SupportedOps: map[string]bool{
+				nvdata.CriteriaOpEqual: true,
+			},
+			Name:               share.ExtractModuleName(PolicyEnvSecretScannerURI),
+			Module:             PolicyEnvSecretScannerURI,
+			ApplicableResource: ResourceWorkload,
+		},
+	}
+}
+
+func (h *EnvVarSecretHandler) BuildPolicySettings(
+	criteria []*nvapis.RESTAdmRuleCriterion,
+) ([]byte, error) {
+	if len(criteria) != 1 {
+		return nil, errors.New("only one criterion is allowed")
+	}
+
+	criterion := criteria[0]
+	if criterion.Value != "false" {
+		return nil, fmt.Errorf("envVarSecrets supports only false value, got: %s", criterion.Value)
+	}
+
+	return []byte("{}"), nil
+}

--- a/internal/handlers/env_var_secret_handler_test.go
+++ b/internal/handlers/env_var_secret_handler_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	nvapis "github.com/neuvector/neuvector/controller/api"
+	nvdata "github.com/neuvector/neuvector/share"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnvVarSecretPolicySettings(t *testing.T) {
+	handler := NewEnvVarSecretHandler()
+
+	tests := []struct {
+		name             string
+		criterion        *nvapis.RESTAdmRuleCriterion
+		expectedSettings []byte
+		expectedError    error
+	}{
+		{
+			name: "envVarSecrets set to false",
+			criterion: &nvapis.RESTAdmRuleCriterion{
+				Name:  RuleEnvVarSecret,
+				Op:    nvdata.CriteriaOpEqual,
+				Value: "false",
+			},
+			expectedSettings: []byte(`{}`),
+		},
+		{
+			name: "envVarSecrets set to true",
+			criterion: &nvapis.RESTAdmRuleCriterion{
+				Name:  RuleEnvVarSecret,
+				Op:    nvdata.CriteriaOpEqual,
+				Value: "true",
+			},
+			expectedError: fmt.Errorf("envVarSecrets supports only false value, got: %s", "true"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			generatedSettings, err := handler.BuildPolicySettings([]*nvapis.RESTAdmRuleCriterion{tt.criterion})
+			require.Equal(t, tt.expectedError, err)
+			require.Equal(t, tt.expectedSettings, generatedSettings)
+		})
+	}
+}

--- a/test/e2e/e2e_single_criterion_test.go
+++ b/test/e2e/e2e_single_criterion_test.go
@@ -49,3 +49,19 @@ func TestConvertSingleCriterion_PVCStorageClass(t *testing.T) {
 		testRuleConversion(t, ruleDir)
 	}
 }
+
+func TestConvertSingleCriterion_EnvVar(t *testing.T) {
+	for _, ruleDir := range []string{
+		"../../test/rules/single_criterion/env_var/contains_all",
+		"../../test/rules/single_criterion/env_var/contains_any",
+		"../../test/rules/single_criterion/env_var/contains_other_than",
+		"../../test/rules/single_criterion/env_var/not_contains_any",
+	} {
+		testRuleConversion(t, ruleDir)
+	}
+}
+
+func TestConvertSingleCriterion_EnvVarSecret(t *testing.T) {
+	ruleDir := "../rules/single_criterion/env_var_secret/secret_forbid"
+	testRuleConversion(t, ruleDir)
+}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -30,7 +30,7 @@ type Config struct {
 	TestWorkspace string   `json:"testWorkspace"`
 	RunKwctl      bool     `json:"runKwctl"` // Whether to run kwctl to verify the rule
 	Accept        []string `json:"accept"`   // List of files that should accept after run kwctl
-	Reject        []string `json:"reject"`   // List of files that should deny after run kwctl
+	Reject        []string `json:"reject"`   // List of files that should reject after run kwctl
 }
 
 type kwctlResponse struct {

--- a/test/fixtures/deployments/env_var_foo_bar.yaml
+++ b/test/fixtures/deployments/env_var_foo_bar.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-bar-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: foo-bar-pod
+  template:
+    metadata:
+      labels:
+        name: foo-bar-pod
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: foo
+              value: "1"
+            - name: bar
+              value: "2"

--- a/test/fixtures/deployments/env_var_foo_rbar.yaml
+++ b/test/fixtures/deployments/env_var_foo_rbar.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-rbar-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: foo-rbar-pod
+  template:
+    metadata:
+      labels:
+        name: foo-rbar-pod
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: foo
+              value: "1"
+            - name: rbar
+              value: "2"

--- a/test/fixtures/deployments/env_var_rfoo_rbar.yaml
+++ b/test/fixtures/deployments/env_var_rfoo_rbar.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rfoo-rbar-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: rfoo-rbar-pod
+  template:
+    metadata:
+      labels:
+        name: rfoo-rbar-pod
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          env:
+            - name: rfoo
+              value: "1"
+            - name: rbar
+              value: "2"

--- a/test/fixtures/deployments/env_var_secrets.yaml
+++ b/test/fixtures/deployments/env_var_secrets.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: env-secrets-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: env-secrets-app
+  template:
+    metadata:
+      labels:
+        app: env-secrets-app
+    spec:
+      containers:
+      - name: app-container
+        image: nginx:latest
+        env:
+          - name: SLACK_WEBHOOK_URL
+            value: "https://hooks.slack.com/services/T1234567890/B1234567890/1234567890abcdefghijklmn"
+          - name: DISCORD_BOT_TOKEN
+            value: "ODc4MzQyNjE4OTIzMDU5MjEx.YSK-XA.1234567890abcdefghijklmnopqrstuvwxyz"
+          - name: MAILGUN_API_KEY
+            value: "key-1234567890abcdefghijklmnopqrstuvwxyz"
+          - name: SENDGRID_API_KEY
+            value: "SG.1234567890abcdefghijklmnopqrstuvwxyz.1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN"
+          - name: TWILIO_AUTH_TOKEN
+            value: "1234567890abcdefghijklmnopqrstuvwxyz"
+          - name: DATADOG_API_KEY
+            value: "1234567890abcdef1234567890abcdef"
+          - name: HEROKU_API_KEY
+            value: "12345678-1234-1234-1234-123456789012"
+          - name: PRIVATE_KEY_PKCS8
+            value: "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC1234567890abc\ndefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdef\n-----END PRIVATE KEY-----"
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"

--- a/test/rules/single_criterion/env_var/contains_all/config.json
+++ b/test/rules/single_criterion/env_var/contains_all/config.json
@@ -1,0 +1,15 @@
+{
+  "description": "Test single criteria rule (not contain all of the env vars)",
+  "runKwctl": true,
+  "testWorkspace": "../fixtures/",
+  "accept": [
+    "deployments/normal.yaml",
+    "deployments/env_var_rfoo_rbar.yaml",
+    "deployments/env_var_foo_rbar.yaml"
+  ],
+  "reject": [
+    "deployments/env_var_foo_bar.yaml"
+  ]
+}
+
+

--- a/test/rules/single_criterion/env_var/contains_all/policy.yaml
+++ b/test/rules/single_criterion/env_var/contains_all/policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  creationTimestamp: null
+  name: neuvector-rule-1000-conversion
+spec:
+  backgroundAudit: true
+  mode: protect
+  module: registry://ghcr.io/kubewarden/policies/environment-variable-policy:v3.0.1
+  mutating: false
+  policyServer: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    - replicasets
+    - daemonsets
+    - statefulsets
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+  settings:
+    criteria: "doesNotContainAllOf"
+    values:
+      - foo
+      - bar
+status:
+  policyStatus: ""

--- a/test/rules/single_criterion/env_var/contains_all/rule.json
+++ b/test/rules/single_criterion/env_var/contains_all/rule.json
@@ -1,0 +1,25 @@
+{
+    "rules": [
+        {
+            "category": "Kubernetes",
+            "cfg_type": "user_created",
+            "comment": "",
+            "containers": [
+                "containers"
+            ],
+            "criteria": [
+                {
+                    "name": "envVars",
+                    "op": "containsAll",
+                    "path": "envVars",
+                    "value": "foo,bar"
+                }
+            ],
+            "critical": false,
+            "disable": false,
+            "id": 1000,
+            "rule_mode": "protect",
+            "rule_type": "deny"
+        }
+    ]
+}

--- a/test/rules/single_criterion/env_var/contains_any/config.json
+++ b/test/rules/single_criterion/env_var/contains_any/config.json
@@ -1,0 +1,15 @@
+{
+  "description": "Test single criteria rule (not contain any of the env vars)",
+  "runKwctl": true,
+  "testWorkspace": "../fixtures/",
+  "accept": [
+    "deployments/normal.yaml",
+    "deployments/env_var_rfoo_rbar.yaml"
+  ],
+  "reject": [
+    "deployments/env_var_foo_bar.yaml",
+    "deployments/env_var_foo_rbar.yaml"
+  ]
+}
+
+

--- a/test/rules/single_criterion/env_var/contains_any/policy.yaml
+++ b/test/rules/single_criterion/env_var/contains_any/policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  creationTimestamp: null
+  name: neuvector-rule-1000-conversion
+spec:
+  backgroundAudit: true
+  mode: protect
+  module: registry://ghcr.io/kubewarden/policies/environment-variable-policy:v3.0.1
+  mutating: false
+  policyServer: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    - replicasets
+    - daemonsets
+    - statefulsets
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+  settings:
+    criteria: "doesNotContainAnyOf"
+    values:
+      - foo
+      - bar
+status:
+  policyStatus: ""

--- a/test/rules/single_criterion/env_var/contains_any/rule.json
+++ b/test/rules/single_criterion/env_var/contains_any/rule.json
@@ -1,0 +1,25 @@
+{
+    "rules": [
+        {
+            "category": "Kubernetes",
+            "cfg_type": "user_created",
+            "comment": "",
+            "containers": [
+                "containers"
+            ],
+            "criteria": [
+                {
+                    "name": "envVars",
+                    "op": "containsAny",
+                    "path": "envVars",
+                    "value": "foo,bar"
+                }
+            ],
+            "critical": false,
+            "disable": false,
+            "id": 1000,
+            "rule_mode": "protect",
+            "rule_type": "deny"
+        }
+    ]
+}

--- a/test/rules/single_criterion/env_var/contains_other_than/config.json
+++ b/test/rules/single_criterion/env_var/contains_other_than/config.json
@@ -1,0 +1,15 @@
+{
+  "description": "Test single criteria rule (contain other than env vars foo and bar)",
+  "runKwctl": true,
+  "testWorkspace": "../fixtures/",
+  "accept": [
+    "deployments/env_var_foo_rbar.yaml",
+    "deployments/env_var_rfoo_rbar.yaml"
+  ],
+  "reject": [
+    "deployments/normal.yaml",
+    "deployments/env_var_foo_bar.yaml"
+  ]
+}
+
+

--- a/test/rules/single_criterion/env_var/contains_other_than/policy.yaml
+++ b/test/rules/single_criterion/env_var/contains_other_than/policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  creationTimestamp: null
+  name: neuvector-rule-1000-conversion
+spec:
+  backgroundAudit: true
+  mode: protect
+  module: registry://ghcr.io/kubewarden/policies/environment-variable-policy:v3.0.1
+  mutating: false
+  policyServer: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    - replicasets
+    - daemonsets
+    - statefulsets
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+  settings:
+    criteria: "containsOtherThan"
+    values:
+      - foo
+      - bar
+status:
+  policyStatus: ""

--- a/test/rules/single_criterion/env_var/contains_other_than/rule.json
+++ b/test/rules/single_criterion/env_var/contains_other_than/rule.json
@@ -1,0 +1,25 @@
+{
+    "rules": [
+        {
+            "category": "Kubernetes",
+            "cfg_type": "user_created",
+            "comment": "",
+            "containers": [
+                "containers"
+            ],
+            "criteria": [
+                {
+                    "name": "envVars",
+                    "op": "containsOtherThan",
+                    "path": "envVars",
+                    "value": "foo,bar"
+                }
+            ],
+            "critical": false,
+            "disable": false,
+            "id": 1000,
+            "rule_mode": "protect",
+            "rule_type": "deny"
+        }
+    ]
+}

--- a/test/rules/single_criterion/env_var/not_contains_any/config.json
+++ b/test/rules/single_criterion/env_var/not_contains_any/config.json
@@ -1,0 +1,15 @@
+{
+  "description": "Test single criteria rule (not contain any of the env vars)",
+  "runKwctl": true,
+  "testWorkspace": "../fixtures/",
+  "accept": [
+    "deployments/env_var_foo_bar.yaml",
+    "deployments/env_var_foo_rbar.yaml"
+  ],
+  "reject": [
+    "deployments/normal.yaml",
+    "deployments/env_var_rfoo_rbar.yaml"
+  ]
+}
+
+

--- a/test/rules/single_criterion/env_var/not_contains_any/policy.yaml
+++ b/test/rules/single_criterion/env_var/not_contains_any/policy.yaml
@@ -1,0 +1,50 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  creationTimestamp: null
+  name: neuvector-rule-1000-conversion
+spec:
+  backgroundAudit: true
+  mode: protect
+  module: registry://ghcr.io/kubewarden/policies/environment-variable-policy:v3.0.1
+  mutating: false
+  policyServer: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    - replicasets
+    - daemonsets
+    - statefulsets
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+  settings:
+    criteria: "containsAnyOf"
+    values:
+      - foo
+      - bar
+status:
+  policyStatus: ""

--- a/test/rules/single_criterion/env_var/not_contains_any/rule.json
+++ b/test/rules/single_criterion/env_var/not_contains_any/rule.json
@@ -1,0 +1,25 @@
+{
+    "rules": [
+        {
+            "category": "Kubernetes",
+            "cfg_type": "user_created",
+            "comment": "",
+            "containers": [
+                "containers"
+            ],
+            "criteria": [
+                {
+                    "name": "envVars",
+                    "op": "notContainsAny",
+                    "path": "envVars",
+                    "value": "foo,bar"
+                }
+            ],
+            "critical": false,
+            "disable": false,
+            "id": 1000,
+            "rule_mode": "protect",
+            "rule_type": "deny"
+        }
+    ]
+}

--- a/test/rules/single_criterion/env_var_secret/secret_forbid/config.json
+++ b/test/rules/single_criterion/env_var_secret/secret_forbid/config.json
@@ -1,0 +1,13 @@
+{
+  "description": "Test single criteria rule (contain other than env vars foo and bar)",
+  "runKwctl": true,
+  "testWorkspace": "../fixtures/",
+  "accept": [
+    "deployments/normal.yaml"
+  ],
+  "reject": [
+    "deployments/env_var_secrets.yaml"
+  ]
+}
+
+

--- a/test/rules/single_criterion/env_var_secret/secret_forbid/policy.yaml
+++ b/test/rules/single_criterion/env_var_secret/secret_forbid/policy.yaml
@@ -1,0 +1,46 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  creationTimestamp: null
+  name: neuvector-rule-1000-conversion
+spec:
+  backgroundAudit: true
+  mode: protect
+  module: registry://ghcr.io/kubewarden/policies/env-variable-secrets-scanner:v1.0.5
+  mutating: false
+  policyServer: default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+    - replicasets
+    - daemonsets
+    - statefulsets
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+    - cronjobs
+  settings: {}
+status:
+  policyStatus: ""

--- a/test/rules/single_criterion/env_var_secret/secret_forbid/rule.json
+++ b/test/rules/single_criterion/env_var_secret/secret_forbid/rule.json
@@ -1,0 +1,25 @@
+{
+    "rules": [
+        {
+            "category": "Kubernetes",
+            "cfg_type": "user_created",
+            "comment": "",
+            "containers": [
+                "containers"
+            ],
+            "criteria": [
+                {
+                    "name": "envVarSecrets",
+                    "op": "=",
+                    "path": "envVarSecrets",
+                    "value": "false"
+                }
+            ],
+            "critical": false,
+            "disable": false,
+            "id": 1000,
+            "rule_mode": "",
+            "rule_type": "deny"
+        }
+    ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Prepare test data for the e2e test
- not support the enforce secret in the deployment.

### Convert rules
- envVars
  - [x] containsAll
  - [x] containsAny
  - [x] containsOtherThan
  - [x] notContainsAny
- envSecret
  - [ ] containsAny
  - [X] notContainsAny

**Which issue(s) this PR fixes**
Issue #36

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
