### PR TITLE
fix: use the nv native global config when the rule is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,31 @@ nvrules2kw convert rules.json
 
 # Specify custom output file
 nvrules2kw convert rules.yaml --output my-policies.yaml
+
+# Override all rules to monitor mode (useful for testing)
+nvrules2kw convert rules.yaml --mode monitor
 ```
 
 By default, the output will be written to `policies.yaml`.
+
+---
+
+### ⚙️ Mode Resolution
+
+The effective enforcement mode for each converted policy is determined by the following priority:
+
+**Priority: CLI `--mode` > File-defined mode > Default mode (`protect`)**
+
+#### Examples
+
+| Case | Format | CLI Mode  | File Mode | Effective Mode           |
+|:----:|:------:|-----------|-----------|--------------------------|
+| A    | yaml   | monitor   | protect   | **monitor** (CLI overrides) |
+| B    | yaml   | ""        | monitor   | **monitor**              |
+| C    | yaml   | ""        | protect   | **protect**              |
+| D    | json   | monitor   | ""        | **monitor** (CLI overrides) |
+| E    | json   | protect   | ""        | **protect** (CLI overrides) |
+| F    | json   | ""        | ""        | **protect** (default)    |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/kubewarden/kubewarden-controller v1.29.0
-	github.com/neuvector/neuvector v0.0.0-20250913040914-6e08b93e0015
+	github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522
 	github.com/olekukonko/tablewriter v1.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.4.1

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/neuvector/neuvector v0.0.0-20250913040914-6e08b93e0015 h1:3aSG+61rD2ru3r1cnyjWVUO08CmvBc81LkB9t71r9ts=
-github.com/neuvector/neuvector v0.0.0-20250913040914-6e08b93e0015/go.mod h1:ziawxmrkXyzEyCweBDq+g1HmH7s0vfxkWbvojkfa8ZY=
+github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522 h1:ZSWl8w/aZjrTViSsh9qulZpRD6HFrx0p99oJnkfPS44=
+github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522/go.mod h1:ziawxmrkXyzEyCweBDq+g1HmH7s0vfxkWbvojkfa8ZY=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=
 github.com/olekukonko/errors v1.1.0/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
 github.com/olekukonko/ll v0.0.9 h1:Y+1YqDfVkqMWuEQMclsF9HUR5+a82+dxJuL1HHSRpxI=

--- a/internal/policy/builder.go
+++ b/internal/policy/builder.go
@@ -18,6 +18,7 @@ const (
 	kwAPIVersion                    = "policies.kubewarden.io/v1"
 	clusterAdmissionPolicyKind      = "ClusterAdmissionPolicy"
 	clusterAdmissionPolicyGroupKind = "ClusterAdmissionPolicyGroup"
+	defaultMode                     = "protect"
 )
 
 type Policy interface{} // *policiesv1.ClusterAdmissionPolicy | *policiesv1.ClusterAdmissionPolicyGroup
@@ -111,11 +112,17 @@ func (b *BaseBuilder) generatePolicyName(rule *nvapis.RESTAdmissionRule) string 
 	return fmt.Sprintf("neuvector-rule-%d-conversion", rule.ID)
 }
 
-func (b *BaseBuilder) getRuleModule(rule *nvapis.RESTAdmissionRule, config share.ConversionConfig) string {
+// getRulelMode determines the effective admission rule mode based on priority:
+// CLI mode > File-defined mode > Default mode.
+func (b *BaseBuilder) getRulelMode(rule *nvapis.RESTAdmissionRule, config share.ConversionConfig) string {
+	if config.Mode != "" {
+		return config.Mode
+	}
+
 	if rule.RuleMode != "" {
 		return rule.RuleMode
 	}
-	return config.Mode
+	return defaultMode
 }
 
 func (b *BaseBuilder) buildNamespaceSelector(criterion *nvapis.RESTAdmRuleCriterion) *metav1.LabelSelector {

--- a/internal/policy/builder_test.go
+++ b/internal/policy/builder_test.go
@@ -56,7 +56,7 @@ func TestGeneratePolicyName(t *testing.T) {
 	}
 }
 
-func TestGetRuleModule(t *testing.T) {
+func TestGetRulelMode(t *testing.T) {
 	builder := BaseBuilder{}
 
 	tests := []struct {
@@ -66,17 +66,17 @@ func TestGetRuleModule(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "rule with rule mode",
+			name: "CLI mode overrides rule mode",
 			rule: &nvapis.RESTAdmissionRule{
 				RuleMode: "protect",
 			},
 			config: share.ConversionConfig{
 				Mode: "monitor",
 			},
-			expected: "protect",
+			expected: "monitor",
 		},
 		{
-			name: "rule without rule mode",
+			name: "CLI mode used when rule mode is not set",
 			rule: &nvapis.RESTAdmissionRule{
 				RuleMode: "",
 			},
@@ -85,11 +85,31 @@ func TestGetRuleModule(t *testing.T) {
 			},
 			expected: "monitor",
 		},
+		{
+			name: "Rule mode used when CLI mode is not provided",
+			rule: &nvapis.RESTAdmissionRule{
+				RuleMode: "protect",
+			},
+			config: share.ConversionConfig{
+				Mode: "",
+			},
+			expected: "protect",
+		},
+		{
+			name: "Default mode used when both CLI and rule modes are not set",
+			rule: &nvapis.RESTAdmissionRule{
+				RuleMode: "",
+			},
+			config: share.ConversionConfig{
+				Mode: "",
+			},
+			expected: "protect",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := builder.getRuleModule(tt.rule, tt.config)
+			actual := builder.getRulelMode(tt.rule, tt.config)
 			require.Equal(t, tt.expected, actual)
 		})
 	}

--- a/internal/policy/cap_builder.go
+++ b/internal/policy/cap_builder.go
@@ -69,7 +69,7 @@ func (b *CAPBuilder) GeneratePolicy(rule *nvapis.RESTAdmissionRule, config share
 			PolicySpec: policiesv1.PolicySpec{
 				Rules:           b.BuildRules(applicableResources),
 				MatchConditions: []admissionregistrationv1.MatchCondition{},
-				Mode:            policiesv1.PolicyMode(b.getRuleModule(rule, config)),
+				Mode:            policiesv1.PolicyMode(b.getRulelMode(rule, config)),
 				Module:          policyHandler.GetModule(),
 				PolicyServer:    config.PolicyServer,
 				BackgroundAudit: config.BackgroundAudit,

--- a/internal/policy/capg_builder.go
+++ b/internal/policy/capg_builder.go
@@ -92,7 +92,7 @@ func (b *CAPGBuilder) GeneratePolicy(rule *nvapis.RESTAdmissionRule, config shar
 				GroupSpec: policiesv1.GroupSpec{
 					Message:         fmt.Sprintf("violate NeuVector rule (id=%d), comment %s", rule.ID, rule.Comment),
 					Rules:           b.BuildRules(applicableResources),
-					Mode:            policiesv1.PolicyMode(b.getRuleModule(rule, config)),
+					Mode:            policiesv1.PolicyMode(b.getRulelMode(rule, config)),
 					PolicyServer:    config.PolicyServer,
 					BackgroundAudit: config.BackgroundAudit,
 					MatchConditions: matchConds,

--- a/internal/policy/capg_builder_test.go
+++ b/internal/policy/capg_builder_test.go
@@ -49,7 +49,7 @@ func TestCAPGBuilder_GeneratePolicy(t *testing.T) {
 			},
 			expectedPolicyName:  "neuvector-rule-1234-conversion",
 			expectedPoliciesLen: 1,
-			expectedMode:        "protect",
+			expectedMode:        "monitor",
 			expectedMessage:     "violate NeuVector rule (id=1234), comment Single Criterion Test",
 			expectedError:       nil,
 		},

--- a/test/fixtures/rule_parser/share_ipc_net_pid.json
+++ b/test/fixtures/rule_parser/share_ipc_net_pid.json
@@ -18,7 +18,7 @@
             "critical": false,
             "disable": false,
             "id": 1000,
-            "rule_mode": "protect",
+            "rule_mode": "monitor",
             "rule_type": "deny"
         },
         {

--- a/test/fixtures/rule_parser/share_ipc_net_pid.yaml
+++ b/test/fixtures/rule_parser/share_ipc_net_pid.yaml
@@ -3,6 +3,10 @@ kind: NvAdmissionControlSecurityRule
 metadata:
   name: local
 spec:
+  config:
+    client_mode: service
+    enable: false
+    mode: monitor
   rules:
   - action: deny
     containers:
@@ -15,7 +19,7 @@ spec:
       value: "true"
     conversion_id_ref: 1000
     disabled: false
-    rule_mode: "protect"
+    rule_mode: ""
   - action: deny
     containers:
     - containers


### PR DESCRIPTION
- bump the nv verson
- use the nv global config to set the rule mode to ensure the mode is transfer correctly

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
