### PR TITLE
feat: support custom rule convertion

### DIFF
--- a/cmd/nvrules2kw/main.go
+++ b/cmd/nvrules2kw/main.go
@@ -89,7 +89,7 @@ func main() {
 				}
 				return ctx, nil
 			},
-			Action: func(_ context.Context, cmd *cli.Command) error {
+			Action: func(ctx context.Context, cmd *cli.Command) error {
 				args := cmd.Args().Slice()
 				if len(args) == 0 {
 					return errors.New("input file is required")
@@ -114,7 +114,7 @@ func main() {
 					Platform:           platform,
 				})
 
-				if err := converter.Convert(ruleFile); err != nil {
+				if err := converter.Convert(ctx, ruleFile); err != nil {
 					return fmt.Errorf("error processing rules: %w", err)
 				}
 				return nil

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/kubewarden/kubewarden-controller v1.31.0
-	github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522
+	github.com/neuvector/neuvector v0.0.0-20251217082449-d56442cccfad
 	github.com/olekukonko/tablewriter v1.1.2
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v3 v3.6.1

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,10 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522 h1:ZSWl8w/aZjrTViSsh9qulZpRD6HFrx0p99oJnkfPS44=
-github.com/neuvector/neuvector v0.0.0-20251001210109-c33c2ea14522/go.mod h1:ziawxmrkXyzEyCweBDq+g1HmH7s0vfxkWbvojkfa8ZY=
+github.com/neuvector/neuvector v0.0.0-20251211073559-4e99b4c9282e h1:DxTe2YOU7amex/eUIGokP63KNhxprodVcoSFzwrv55w=
+github.com/neuvector/neuvector v0.0.0-20251211073559-4e99b4c9282e/go.mod h1:sp9pO/F9EIubfRMh5Kzo1imMc2ur6ylW6Ab7nJ3cXC0=
+github.com/neuvector/neuvector v0.0.0-20251217082449-d56442cccfad h1:cG/KTH/4TL80XhAaSs7hFKbgJo+JM5qLZcYOLKKhy8k=
+github.com/neuvector/neuvector v0.0.0-20251217082449-d56442cccfad/go.mod h1:sp9pO/F9EIubfRMh5Kzo1imMc2ur6ylW6Ab7nJ3cXC0=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 h1:zrbMGy9YXpIeTnGj4EljqMiZsIcE09mmF8XsD5AYOJc=
 github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6/go.mod h1:rEKTHC9roVVicUIfZK7DYrdIoM0EOr8mK1Hj5s3JjH0=
 github.com/olekukonko/errors v1.1.0 h1:RNuGIh15QdDenh+hNvKrJkmxxjV4hcS50Db478Ou5sM=

--- a/internal/convert/convert_test.go
+++ b/internal/convert/convert_test.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -96,7 +97,7 @@ func TestProcessSingleRuleFailed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := converter.convertRule(tt.rule)
+			result := converter.convertRule(context.Background(), tt.rule)
 			require.Equal(t, tt.expectedID, result.id)
 			require.Equal(t, tt.expectedPass, result.pass)
 			require.Equal(t, tt.expectedNotes, result.notes)
@@ -259,7 +260,7 @@ func TestOutputPolicies_Stdout(t *testing.T) {
 		BackgroundAudit: true,
 		ShowSummary:     false,
 	})
-	err = converter.Convert(testRule)
+	err = converter.Convert(context.Background(), testRule)
 	require.NoError(t, err)
 
 	w.Close()

--- a/internal/convert/test_utils.go
+++ b/internal/convert/test_utils.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +45,7 @@ func testRuleConversion(t *testing.T, ruleDir string) {
 	})
 
 	rulePath := filepath.Join(ruleDir, "rule.json")
-	err := converter.Convert(rulePath)
+	err := converter.Convert(context.Background(), rulePath)
 	require.NoError(t, err)
 	defer os.Remove(OutputFile)
 
@@ -62,7 +63,7 @@ func testRuleConversionWithFail(t *testing.T, ruleDir string, mode string) {
 	})
 
 	rulePath := filepath.Join(ruleDir, "rule.json")
-	err := converter.Convert(rulePath)
+	err := converter.Convert(context.Background(), rulePath)
 
 	require.Error(t, err)
 	require.NoFileExists(t, OutputFile)

--- a/internal/customrule/custom_rule.go
+++ b/internal/customrule/custom_rule.go
@@ -1,0 +1,119 @@
+package customrule
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	nvapis "github.com/neuvector/neuvector/controller/api"
+	"github.com/neuvector/neuvector/controller/opa"
+	nvshare "github.com/neuvector/neuvector/share"
+)
+
+const (
+	RuleCustom        = "customPath"
+	RegoDir           = "rego_policies"
+	KubewardenPackage = "package kubernetes.admission"
+)
+
+func IsCustomRule(name string) bool {
+	return name == RuleCustom || name == ""
+}
+
+func convertContainers(containers []string) uint8 {
+	if len(containers) == 0 {
+		return 0
+	}
+	var mask uint8
+	for _, c := range containers {
+		switch c {
+		case nvshare.AdmCtrlRuleContainers:
+			mask |= nvshare.AdmCtrlRuleContainersN
+		case nvshare.AdmCtrlRuleInitContainers:
+			mask |= nvshare.AdmCtrlRuleInitContainersN
+		case nvshare.AdmCtrlRuleEphemeralContainers:
+			mask |= nvshare.AdmCtrlRuleEphemeralContainersN
+		}
+	}
+
+	return mask
+}
+
+func cfgTypeFromString(cfgType string) nvshare.TCfgType {
+	switch cfgType {
+	case "learned":
+		return nvshare.Learned
+	case "ground":
+		return nvshare.GroundCfg
+	case "federal":
+		return nvshare.FederalCfg
+	case "system_defined":
+		return nvshare.SystemDefined
+	default:
+		return nvshare.UserCreated
+	}
+}
+
+// convertToCLUSAdmissionRule converts RESTAdmissionRule to CLUSAdmissionRule.
+func convertToCLUSAdmissionRule(
+	rule *nvapis.RESTAdmissionRule,
+) (*nvshare.CLUSAdmissionRule, error) {
+	// Convert each RESTAdmRuleCriterion to CLUSAdmRuleCriterion.
+	// Both types are identical by design; marshal/unmarshal is safer than manual field copying.
+	clusCriteria := make([]*nvshare.CLUSAdmRuleCriterion, 0, len(rule.Criteria))
+	for _, criterion := range rule.Criteria {
+		jsonCriterion, err := json.Marshal(criterion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal criterion: %w", err)
+		}
+		var clusCriterion nvshare.CLUSAdmRuleCriterion
+		err = json.Unmarshal(jsonCriterion, &clusCriterion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal criterion: %w", err)
+		}
+		clusCriteria = append(clusCriteria, &clusCriterion)
+	}
+
+	return &nvshare.CLUSAdmissionRule{
+		ID:         rule.ID,
+		Category:   rule.Category,
+		Comment:    rule.Comment,
+		Criteria:   clusCriteria,
+		Disable:    rule.Disable,
+		Critical:   rule.Critical,
+		CfgType:    cfgTypeFromString(rule.CfgType),
+		RuleType:   rule.RuleType,
+		RuleMode:   rule.RuleMode,
+		Containers: convertContainers(rule.Containers),
+	}, nil
+}
+
+// BuildRegoPolicy generates a Kubewarden-compatible Rego policy from a NeuVector admission rule.
+func BuildRegoPolicy(rule *nvapis.RESTAdmissionRule) error {
+	clusRule, err := convertToCLUSAdmissionRule(rule)
+	if err != nil {
+		return fmt.Errorf("failed to convert rule to CLUSAdmissionRule: %w", err)
+	}
+
+	options := &opa.RegoConversionOptions{
+		PackageName:            "kubernetes.admission",
+		GenerateKubewardenMode: true,
+	}
+
+	regoCode, err := opa.GenerateRegoCode(clusRule, options)
+	if err != nil {
+		return fmt.Errorf("failed to generate rego code: %w", err)
+	}
+
+	if err = os.MkdirAll(RegoDir, 0750); err != nil {
+		return fmt.Errorf("failed to create Rego directory: %w", err)
+	}
+
+	regoPolicyPath := filepath.Join(RegoDir, fmt.Sprintf("nv_rule_%d.rego", rule.ID))
+	if err = os.WriteFile(regoPolicyPath, []byte(regoCode), 0600); err != nil {
+		return fmt.Errorf("failed to write rego code: %w", err)
+	}
+
+	return nil
+}

--- a/internal/policy/cap_builder.go
+++ b/internal/policy/cap_builder.go
@@ -32,18 +32,20 @@ func (b *CAPBuilder) GeneratePolicy(rule *nvapis.RESTAdmissionRule, config share
 		if !exists {
 			return nil, fmt.Errorf("no handler found for criterion: %s", criterion.Name)
 		}
+
+		// Handle namespace selector separately
 		if criterion.Name == handlers.RuleNamespace {
 			if namespaceSelector != nil {
 				return nil, errors.New("rule skipped: contains multiple namespace selectors")
 			}
 			namespaceSelector = b.buildNamespaceSelector(criterion)
-		} else {
-			policyHandler = handler
-			policyCriteria = append(policyCriteria, criterion)
-			applicableResources = append(applicableResources, handler.GetApplicableResource())
+			continue
 		}
-	}
 
+		policyHandler = handler
+		policyCriteria = append(policyCriteria, criterion)
+		applicableResources = append(applicableResources, handler.GetApplicableResource())
+	}
 	// Ignore rules that contain only namespace criteria as they don't represent meaningful policies
 	if policyHandler == nil {
 		return nil, errors.New(

--- a/internal/policy/cap_builder_test.go
+++ b/internal/policy/cap_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	v1 "github.com/kubewarden/kubewarden-controller/api/policies/v1"
+	"github.com/neuvector/neuvector-kubewarden-policy-converter/internal/customrule"
 	"github.com/neuvector/neuvector-kubewarden-policy-converter/internal/handlers"
 	"github.com/neuvector/neuvector-kubewarden-policy-converter/internal/share"
 	nvapis "github.com/neuvector/neuvector/controller/api"
@@ -148,6 +149,32 @@ func TestCAPBuilder_GeneratePolicy(t *testing.T) {
 				handlers.RuleNamespace: handlers.NewNamespaceHandler(),
 			},
 			expectedError: errors.New("rule skipped: contains multiple namespace selectors"),
+		},
+		{
+			name: "error when rule contains only customPath criterion",
+			rule: &nvapis.RESTAdmissionRule{
+				ID:      1001,
+				Comment: "Custom Path Rule Test",
+				Criteria: []*nvapis.RESTAdmRuleCriterion{
+					{
+						Name:      customrule.RuleCustom,
+						Op:        nvdata.CriteriaOpContainsAll,
+						Path:      "item.spec.containers[_].name",
+						Type:      customrule.RuleCustom,
+						Value:     "nginx,redis",
+						ValueType: customrule.RuleCustom,
+					},
+				},
+			},
+			config: share.ConversionConfig{
+				PolicyServer:    "test-server",
+				Mode:            "monitor",
+				BackgroundAudit: false,
+			},
+			handlers: map[string]share.PolicyHandler{
+				handlers.RuleShareIPC: handlers.NewHostNamespaceHandler(),
+			},
+			expectedError: errors.New("no handler found for criterion: customPath"),
 		},
 	}
 


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
- use neuvector to genertae rego file, then converter will convert into wasm
- user can upload the wasm to remote registry then use it as policy


**Which issue(s) this PR fixes**
Issue #66

**Special notes for your reviewer**:
- I've test the approach for wasm transformation, the flaw is that the error message is not clear. However, functional wise the transformation works

```bash
Error from server: error when creating "test/fixtures/deployments/labels_foo_rbar.yaml": admission webhook "clusterwide-neuvector-rule-1000-conversion.kubewarden.admission" denied the request without explanation
```

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
