### PR TITLE
feat: refactor ruleParsingResult to summaryEntry

### DIFF
--- a/internal/convert/types.go
+++ b/internal/convert/types.go
@@ -20,9 +20,8 @@ type Policy interface {
 	runtime.Object
 }
 
-type ruleParsingResult struct {
+type summaryEntry struct {
 	id     uint32
-	pass   bool
+	status string
 	notes  string
-	policy Policy // Either ClusterAdmissionPolicy or ClusterAdmissionPolicyGroup
 }

--- a/test/mock/rules.yaml
+++ b/test/mock/rules.yaml
@@ -1,0 +1,77 @@
+apiVersion: neuvector.com/v1
+kind: NvAdmissionControlSecurityRule
+metadata:
+  creationTimestamp: null
+  name: local
+spec:
+  config:
+    client_mode: service
+    enable: false
+    mode: monitor
+  rules:
+  - action: deny
+    containers:
+    - containers
+    conversion_id_ref: 1000
+    criteria:
+    - name: annotations
+      op: containsAll
+      path: annotations
+      value: foo
+    - name: cveHighCount
+      op: '>='
+      path: cveHighCount
+      value: "5"
+    disabled: false
+    rule_mode: ""
+  - action: deny
+    containers:
+    - containers
+    conversion_id_ref: 1001
+    criteria:
+    - name: cveHighCount
+      op: '>='
+      path: cveHighCount
+      value: "4"
+    disabled: false
+    rule_mode: ""
+  - action: deny
+    containers:
+    - containers
+    conversion_id_ref: 1002
+    criteria:
+    - name: customPath
+      op: containsAll
+      path: item.spec.initContainers[_].lifecycle.postStart.tcpSocket.host
+      type: customPath
+      value: localhost
+      value_type: string
+    - name: customPath
+      op: containsAny
+      path: item.spec.containers[_].image
+      type: customPath
+      value: redis:latest,nginx:latest,sbomscanner
+      value_type: string
+    - name: runAsPrivileged
+      op: =
+      path: runAsPrivileged
+      value: "true"
+      value_type: string
+    - name: imageScanned
+      op: =
+      path: imageScanned
+      value: "true"
+      value_type: string
+    disabled: false
+    rule_mode: protect
+  - action: allow
+    containers:
+    - containers
+    conversion_id_ref: 1004
+    criteria:
+    - name: cveHighCount
+      op: '>='
+      path: cveHighCount
+      value: "4"
+    disabled: false
+    rule_mode: ""


### PR DESCRIPTION


**What this PR does / why we need it**:
- remove ruleParsingResult replace with summaryEntry
- ensure convertRule return policy, error, and the caller based on the error to run, which more go idiomatic
- Added test fixture `test/mock/rules.yaml` for test `convertRules` function- Contains 4 admission rules covering different scenarios:
  - 2 standard rules (annotations + cveHighCount) → generates 2 YAML policies
  - 1 custom rule (customPath criteria) → generates 1 rego-only policy
  - 1 allow rule → skipped (only deny rules supported)

**Which issue(s) this PR fixes**
Issue #139

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
