### PR TITLE
fix: operator value is wrong in envVarSecrets rule migration

### DIFF
--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -211,7 +211,7 @@ With these steps, you end up with a working Kubewarden policy that enforces your
 
 | Operator | Values          | Notes |
 | -------- | --------------- | ----- |
-| `=`      | `true`, `false` |       |
+| `=`      | `false` |       |
 
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- note mentioned the envVarSecrets should not use the value true, but the operator value is wrong.

**Which issue(s) this PR fixes**
Issue #165

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
