### PR TITLE
ci: ignore all of the ci update from neuvector

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
           - "k8s.io/code-generator"
           - "k8s.io/component-base"
           - "sigs.k8s.io/controller-runtime"
+    ignore:
+      - dependency-name: "github.com/neuvector/neuvector"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

- We only use the github.com/neuvector/neuvector module for its type/struct definitions, so we don’t need Dependabot to keep bumping it automatically

**Which issue(s) this PR fixes**
Issue #170


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
