### PR TITLE
chore(deps): auto-update go versions

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,51 @@
+name: Updatecli
+on:
+  # Allow to manually trigger Updatecli
+  workflow_dispatch:
+  # Trigger Updatecli on main branch changes
+  # To rebase existing PR
+  push:
+    branches: [main]
+  # Trigger Updatecli pullrequest to test potential changes
+  pull_request:
+    branches: [main]
+  # Periodically checks update
+  schedule:
+    # Run every hour
+    - cron: "0 * * * *"
+
+jobs:
+  updatecli:
+    name: Run Updatecli
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for updatecli to update the repository
+      pull-requests: write # for updatecli to create a PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@e71be7554f3f940bc439cf720b3e4e379823c562 # v3.2.0
+
+      - name: Run Updatecli (dryrun)
+        if: github.ref != 'refs/heads/main'
+        env:
+          # Until this repository is under the rancher-sandbox GitHub organisation
+          # It's easier to use the default GITHUB_TOKEN but ultimately
+          # it's gonna be better to use a GitHub App token
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli compose diff --file updatecli/updatecli-compose.yaml"
+
+      - name: Run Updatecli
+        if: github.ref == 'refs/heads/main'
+        env:
+          # Until this repository is under the rancher-sandbox GitHub organisation
+          # It's easier to use the default GITHUB_TOKEN but ultimately
+          # it's gonna be better to use a GitHub App token
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_GITHUB_OWNER: ${{ github.repository_owner }}
+        run: "updatecli compose apply --file updatecli/updatecli-compose.yaml"

--- a/updatecli/updatecli-compose.yaml
+++ b/updatecli/updatecli-compose.yaml
@@ -1,0 +1,6 @@
+policies:
+  - name: Update Go version
+    config:
+      - "updatecli.d"
+    values:
+      - values.yaml

--- a/updatecli/updatecli.d/go.yaml
+++ b/updatecli/updatecli.d/go.yaml
@@ -1,0 +1,61 @@
+name: Update Golang version
+
+pipelineid: golang/version
+
+sources:
+  go:
+    name: Get latest Golang version
+    kind: golang
+
+conditions:
+  docker:
+    name: Check Docker image tag
+    kind: dockerimage
+    sourceid: go
+    spec:
+      image: docker.io/library/golang
+
+targets:
+  gomod:
+    name: 'deps(go): update Go version to {{ source "go" }}'
+    sourceid: go
+    kind: golang/gomod
+    scmid: default
+    spec:
+      file: go.mod
+
+actions:
+  default:
+    title: 'deps(go): update Go to {{ source "go" }} version'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        Automatic Golang version {{ source "go" }} update.
+        This PR has been created by the automation used to automatically update the Golang version in the neuvector-kubewarden-policy-converter project
+        REMEMBER IF YOU WANT TO MERGE IN A SINGLE COMMIT CHANGES AND VERSION BUMP, YOU MUST SQUASH THE COMMIT BEFORE MERGING THIS PR!
+      draft: false
+      labels:
+        - "chore"
+        - "dependencies"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.author }}"
+      email: "{{ .github.email }}"
+      owner: "{{ requiredEnv .github.owner }}"
+      repository: "neuvector-kubewarden-policy-converter"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ requiredEnv .github.user }}"
+      branch: "{{ .github.branch }}"
+      commitusingapi: true
+      commitmessage:
+        type: "chore"
+        scope: deps
+        title: "update Golang version"
+        hidecredit: true
+        footers: "Signed-off-by: NeuVectorKubewardenPolicyConverter bot <neuvector-kubewarden-policy-converter-bot@users.noreply.github.com>"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,7 @@
+github:
+  owner: "UPDATECLI_GITHUB_OWNER"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  author: "NeuVectorKubewardenPolicyConverter bot"
+  user: "UPDATECLI_GITHUB_OWNER"
+  email: "neuvector-kubewarden-policy-converter-bot@users.noreply.github.com"


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

During the discussion about golang compiler versions, it was discovered that the go.mod is not up-to-date in this repo, which would lead release.yml to use an old golang compiler, which is problematic.

This PR introduces updatecli to update go.mod's version.  

Alternatively, renovate can be used, but it's not considered as the best option because:

1. This repo doesn't use renovate.
2. Most of existing neuvector repo use updatecli to update go.mod and container images at the same time.  It's better to sync with other repos. 

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
